### PR TITLE
Driver Pesticide Update

### DIFF
--- a/R/driver.R
+++ b/R/driver.R
@@ -2,6 +2,7 @@
 #' @param toxval.db Database version
 #' @param sys.date The date of the database export
 #' @param run.export Whether to run the export.for.bmdh function (Default: TRUE)
+#' @param include.pesticides Flag to include pesticides in output or not
 #' @export
 #' @title driver
 #' @description Run all of the calculations to go from database export to calculation of final BMDh values
@@ -15,15 +16,15 @@
 #' }
 #' @rdname driver
 #-------------------------------------------------------------------------------
-driver <- function(toxval.db="res_toxval_v95", sys.date=Sys.Date(), run.export=TRUE) {
+driver <- function(toxval.db="res_toxval_v95", sys.date=Sys.Date(), run.export=TRUE, include.pesticides=FALSE) {
   printCurrentFunction()
   if(run.export) export.for.bmdh(toxval.db)
   # Skip filter.for.bmdh() with improved JSON storage of record_source entries
   # filter.for.bmdh(toxval.db,sys.date)
-  filter.for.lel(toxval.db,sys.date)
+  filter.for.lel(toxval.db,sys.date,include.pesticides)
   filter.for.multi.noel(toxval.db,sys.date)
-  filter.summary(toxval.db,sys.date,do.load=T)
-  study_group.multichem(toxval.db,sys.date)
+  filter.summary(toxval.db,sys.date,do.load=T,include.pesticides)
+  study_group.multichem(toxval.db,sys.date,include.pesticides)
   dcap.counts(toxval.db,sys.date)
   studies.per.chemical(toxval.db,sys.date)
   toxvaldb.statplots(to.file=T,toxval.db,sys.date)

--- a/R/filter.for.lel.R
+++ b/R/filter.for.lel.R
@@ -1,8 +1,9 @@
 #-----------------------------------------------------------------------------------
 #' @param toxval.db Database version
 #' @param sys.date The date of the export
+#' @param include.pesticides Flag to include pesticides in output or not
 #' @return Write a file with the filtered results:ToxValDB for BMDh filtered {toxval.db} {sys.date}.xlsx
-#' @export 
+#' @export
 #' @title filter.for.lel
 #' @description Filter the exported records for redundancy
 #' @details Filters LEL, NEL values where a LOAEL/NOAEL value exists
@@ -12,15 +13,17 @@
 #'  #EXAMPLE1
 #'  }
 #' }
-#' @seealso 
+#' @seealso
 #'  \code{\link[openxlsx]{read.xlsx}}, \code{\link[openxlsx]{createStyle}}, \code{\link[openxlsx]{write.xlsx}}
 #' @rdname filter.for.lel
 #' @importFrom openxlsx read.xlsx createStyle write.xlsx
 #-----------------------------------------------------------------------------------
-filter.for.lel <- function(toxval.db="res_toxval_v95",sys.date=Sys.Date()) {
+filter.for.lel <- function(toxval.db="res_toxval_v95", sys.date=Sys.Date(), include.pesticides=FALSE) {
   printCurrentFunction(toxval.db)
   dir = "data/"
   file = paste0(dir,"results/ToxValDB for BMDh ",toxval.db," ",sys.date,".xlsx")
+  if(include.pesticides) file = paste0(dir,"results/ToxValDB for BMDh WITH PESTICIDES ",
+                                       toxval.db," ",sys.date,".xlsx")
   print(file)
   res = readxl::read_xlsx(file)
 

--- a/R/filter.summary.R
+++ b/R/filter.summary.R
@@ -1,6 +1,7 @@
 #-----------------------------------------------------------------------------------
 #' @param toxval.db Database version
 #' @param sys.date The date of the export
+#' @param include.pesticides Flag to include pesticides in output or not
 #' @return Write a file with the filtered results:ToxValDB for BMDh LEL NEL multiNOEL filtered {toxval.db} {sys.date}.xlsx
 #' @export
 #' @title filter.summary
@@ -20,12 +21,13 @@
 #' @rdname filter.summary
 #' @importFrom openxlsx read.xlsx createStyle write.xlsx
 #-----------------------------------------------------------------------------------
-filter.summary <- function(toxval.db="res_toxval_v95",sys.date=Sys.Date(),do.load=TRUE) {
+filter.summary <- function(toxval.db="res_toxval_v95",sys.date=Sys.Date(),do.load=TRUE,include.pesticides=FALSE) {
   printCurrentFunction(toxval.db)
   dir = "data/"
 
   if(do.load) {
     file = paste0(dir,"results/ToxValDB for BMDh ",toxval.db," ",sys.date,".xlsx")
+    if(include.pesticides) file = paste0(dir,"results/ToxValDB for BMDh WITH PESTICIDES ",toxval.db," ",sys.date,".xlsx")
     print(file)
     t1 = openxlsx::read.xlsx(file)
 

--- a/R/study_group.multichem.R
+++ b/R/study_group.multichem.R
@@ -1,27 +1,30 @@
 #-----------------------------------------------------------------------------------
 #' @param toxval.db Database version
 #' @param sys.date The date of the export
+#' @param include.pesticides Flag to include pesticides in output or not
 #' @return Write a file with the filtered results:ToxValDB for BMDh LEL NEL multiNOEL filtered {toxval.db} {sys.date}.xlsx
-#' @export 
+#' @export
 #' @title study_group.multichem
 #' @description Find study groups that span multiple chemicals
 #' @details DETAILS
-#' @examples 
+#' @examples
 #' \dontrun{
 #' if(interactive()){
 #'  #EXAMPLE1
 #'  }
 #' }
-#' @seealso 
+#' @seealso
 #'  \code{\link[openxlsx]{read.xlsx}}, \code{\link[openxlsx]{createStyle}}, \code{\link[openxlsx]{write.xlsx}}
 #' @rdname study_group.multichem
 #' @importFrom openxlsx read.xlsx createStyle write.xlsx
 #-----------------------------------------------------------------------------------
-study_group.multichem <- function(toxval.db="res_toxval_v95",sys.date=Sys.Date()) {
+study_group.multichem <- function(toxval.db="res_toxval_v95", sys.date=Sys.Date(), include.pesticides=FALSE) {
   printCurrentFunction(toxval.db)
   dir = "data/"
 
   file = paste0(dir,"results/ToxValDB for BMDh ",toxval.db," ",sys.date,".xlsx")
+  if(include.pesticides) file = paste0(dir,"results/ToxValDB for BMDh WITH PESTICIDES ",
+                                       toxval.db," ",sys.date,".xlsx")
   print(file)
   res = readxl::read_xlsx(file)
 


### PR DESCRIPTION
There wasn't previously a way to run the entire toxvaldbBMDh pipeline without pesticide filtering, so I've added the include.pesticides parameter to relevant functions to enable this.